### PR TITLE
Configure: Moved CXX11 requirement to --with-online conditional (Imported !84)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,6 @@ AC_PROG_CC
 AM_PROG_CC_C_O
 AC_PROG_CXX
 AC_PROG_CXXCPP
-AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
 AC_PROG_RANLIB
 
 PKG_PROG_PKG_CONFIG
@@ -125,6 +124,7 @@ AC_ARG_WITH([online],[AS_HELP_STRING([--with-online@<:@=DIR@:>@],
                       [use_online=yes],[use_online=no])
 if test "x${use_online}" != "xno" ; then
     AM_CONDITIONAL(USE_ONLINE, true)
+    AX_CXX_COMPILE_STDCXX(11, noext, mandatory)
     PKG_CHECK_MODULES_STATIC([ARGOBOTS], [argobots], [],
                       [AC_MSG_ERROR([Could not find working argobots installation via pkg-config])])
     PKG_CHECK_MODULES_STATIC([SWM], [swm], [],


### PR DESCRIPTION
Original MR Author: Neil McGlohon
Original MR ID: 84
Original MR URL: https://xgitlab.cels.anl.gov/codes/codes/merge_requests/84
______
This is to address issue #169.

The C++ 11 requirement was added to configure.ac in commit 5600772380abd25f7aabccf22862a83107a1250f. Since CODES builds just fine without C++11, it seems like this requirement was added for support of SWM workloads which aren't built unless `--with-online=` is specified. So this requirement has been moved to reside within that conditional so that certain legacy machines that may not have updated to the 8 year old standard yet can still compile CODES without complaint if they don't need SWM.